### PR TITLE
Revert "incorrect example"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An extension to add a close button and/or prompts.
 "_close": {
 	"_isEnabled": true,
 	"_iconTypeClass": "icon-cross",
-	"_tooltip": "Close",
+	"tooltip": "Close",
 	"_showTooltip": true,
 	"_layout": "right",
 	"_promptIfIncomplete": null,


### PR DESCRIPTION
Reverts cgkineo/adapt-close#3

Just talked to Tom G and he confirmed that this is an incorrect pull request. Due to the way that underscores are used as a way to tell translations companies what to touch/not touch. However this means that all of the other "_tooltip" attributes need to converted to "tooltip"

![incorrect underscores](https://cloud.githubusercontent.com/assets/1676635/10480758/f4d42ff4-7263-11e5-91b0-35ee203b9a92.jpg)


