### PR TITLE
Deep iframe case fixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ An extension to add a close button and/or prompts.
 		<td><code>false</code></td>
 	</tr>
 	<tr>
-		<td colspan="2"><code>_isLMS</code></td>
+		<td colspan="2"><code>_closeViaLMSFinish</code></td>
 		<td>Boolean</td>
 		<td>Set to <code>true</code> to add LMS support. Plugin calls <code>LMSFinish()</code> function for closing course instead of <code>window.close()</code></td>
 		<td><code>false</code></td>

--- a/README.md
+++ b/README.md
@@ -30,10 +30,16 @@ An extension to add a close button and/or prompts.
 		<td><code>false</code></td>
 	</tr>
 	<tr>
-		<td rowspan="11"><code>_button</code></td>
+		<td rowspan="12"><code>_button</code></td>
 		<td colspan="2"><code>_isEnabled</code></td>
 		<td>Boolean</td>
 		<td>Adds a close button to the navigation bar</td>
+		<td><code>false</code></td>
+	</tr>
+	<tr>
+		<td colspan="2"><code>_isLMS</code></td>
+		<td>Boolean</td>
+		<td>Set to <code>true</code> to add LMS support. Plugin calls <code>LMSFinish()</code> function for closing course instead of <code>window.close()</code></td>
 		<td><code>false</code></td>
 	</tr>
 	<tr>

--- a/js/adapt-close.js
+++ b/js/adapt-close.js
@@ -46,11 +46,9 @@ define([ "core/js/adapt" ], function(Adapt) {
 			var config = Adapt.course.get("_close");
 			config.browserPromptIfIncomplete = config.browserPromptIfComplete = false;
 
-			// if course placed deeper than 1 iframe we can't close window directly,
-			// therefore just trigger unload window events
-			if(top.window.frames.length > 1) {
+			if(config._button._isLMS) {
 				$(window)
-					 .trigger('unload')
+					.trigger('unload')
 					.trigger('beforeunload');
 			} else {
 				top.window.close();

--- a/js/adapt-close.js
+++ b/js/adapt-close.js
@@ -46,7 +46,7 @@ define([ "core/js/adapt" ], function(Adapt) {
 			var config = Adapt.course.get("_close");
 			config.browserPromptIfIncomplete = config.browserPromptIfComplete = false;
 
-			if(config._button._isLMS) {
+			if(config._button._closeViaLMSFinish) {
 				$(window)
 					.trigger('unload')
 					.trigger('beforeunload');

--- a/js/adapt-close.js
+++ b/js/adapt-close.js
@@ -46,7 +46,15 @@ define([ "core/js/adapt" ], function(Adapt) {
 			var config = Adapt.course.get("_close");
 			config.browserPromptIfIncomplete = config.browserPromptIfComplete = false;
 
-			top.window.close();
+			// if course placed deeper than 1 iframe we can't close window directly,
+			// therefore just trigger unload window events
+			if(top.window.frames.length > 1) {
+				$(window)
+					 .trigger('unload')
+					.trigger('beforeunload');
+			} else {
+				top.window.close();
+			}
 		}
 
 	});

--- a/js/adapt-close.js
+++ b/js/adapt-close.js
@@ -46,10 +46,9 @@ define([ "core/js/adapt" ], function(Adapt) {
 			var config = Adapt.course.get("_close");
 			config.browserPromptIfIncomplete = config.browserPromptIfComplete = false;
 
-			if(config._button._closeViaLMSFinish) {
-				$(window)
-					.trigger('unload')
-					.trigger('beforeunload');
+			if (config._button._closeViaLMSFinish) {
+                var scorm = require('extensions/adapt-contrib-spoor/js/scorm/wrapper');
+                if (scorm) scorm.getInstance().finish();
 			} else {
 				top.window.close();
 			}

--- a/properties.schema
+++ b/properties.schema
@@ -39,7 +39,7 @@
                       "default": false,
                       "title": "Is LMS?",
                       "inputType": "Checkbox",
-                      "help": "Set to 'true' to add LMS support. Plugin calls LMSFinish() function for closing course"
+                      "help": "Set to 'true' to add LMS support. Plugin calls LMSFinish() function for closing course instead of window.close()"
                     },
                     "_isEnabled": {
                       "type": "boolean",

--- a/properties.schema
+++ b/properties.schema
@@ -34,6 +34,13 @@
                   "type": "object",
                   "title": "Button",
                   "properties": {
+                    "_isLMS": {
+                      "type": "boolean",
+                      "default": false,
+                      "title": "Is LMS?",
+                      "inputType": "Checkbox",
+                      "help": "Set to 'true' to add LMS support. Plugin calls LMSFinish() function for closing course"
+                    },
                     "_isEnabled": {
                       "type": "boolean",
                       "default": true,

--- a/properties.schema
+++ b/properties.schema
@@ -34,10 +34,10 @@
                   "type": "object",
                   "title": "Button",
                   "properties": {
-                    "_isLMS": {
+                    "_closeViaLMSFinish": {
                       "type": "boolean",
                       "default": false,
-                      "title": "Is LMS?",
+                      "title": "Close via LMSFinish?",
                       "inputType": "Checkbox",
                       "help": "Set to 'true' to add LMS support. Plugin calls LMSFinish() function for closing course instead of window.close()"
                     },


### PR DESCRIPTION
The problem appears, when we use some LMS vendor (e.g. LearnUpon), which loads course in more than 1 iframe. In this case we can't simply call `top.window.close()`, because we get error: 

> Scripts may close only the windows that were opened by it.

I found, that we can check number of iframes of top.window and if it have more than 1 iframe we can just trigger window's "unload" events. It will trigger `LMSFinish()` function and LMS will close window.
