### PR TITLE
Update: remove legacy nav btn float (fixes #30)

### DIFF
--- a/less/close.less
+++ b/less/close.less
@@ -1,8 +1,4 @@
 .nav {
-  &__adaptclose-btn {
-    .u-float-right;
-  }
-
   &__adaptclose-btn .icon {
     .icon-cross;
   }


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-close/issues/30

### Update
The nav button [float](https://github.com/cgkineo/adapt-close/blob/2d2871a85b785da2ee993899360f60d082332cdd/less/close.less#L3) style is no longer required since the plugin was updated to support [`data-order`](https://github.com/cgkineo/adapt-close/commit/a32aaafe4d26ce317d7fb12a0ce67086529596cc).

Core also [overrides](https://github.com/adaptlearning/adapt-contrib-core/blob/8b36e3ee68941b62e711198f49fa9345c1758132/less/core/nav.less#L38) any `.nav__btn` `float` styles. 