### PR TITLE
Update: Use globals closeButton for aria label (fixes #38)

### DIFF
--- a/example.json
+++ b/example.json
@@ -1,9 +1,9 @@
     // To go in the course.json file
     "_extensions": {
         "_close": {
-          "closeButton": "Select here to close the window.",
           "_navOrder": 110,
           "navLabel": "Close",
+          "ariaLabel": "Select here to close the course.",
           "_navTooltip": {
             "_isEnabled": true,
             "text": "Close"
@@ -17,7 +17,6 @@
         "_button": {
             "_isEnabled": true,
             "_closeViaLMSFinish": false,
-            "navigationAriaLabel": "Close course button",
             "_notifyPromptIfIncomplete": {
                 "_isEnabled": false,
                 "title": "Confirm close",

--- a/example.json
+++ b/example.json
@@ -1,6 +1,7 @@
     // To go in the course.json file
     "_extensions": {
         "_close": {
+          "closeButton": "Select here to close the window.",
           "_navOrder": 110,
           "navLabel": "Close",
           "_navTooltip": {

--- a/js/CloseNavigationButtonView.js
+++ b/js/CloseNavigationButtonView.js
@@ -4,16 +4,10 @@ import tooltips from 'core/js/tooltips';
 import notify from 'core/js/notify';
 
 export default class CloseNavigationButtonView extends NavigationButtonView {
-
   attributes() {
-    const attributes = this.model.toJSON();
     return {
-      name: attributes._id,
-      role: attributes._role === 'button' ? undefined : attributes._role,
-      'aria-label': Adapt.adaptclose.config._button.navigationAriaLabel,
-      'data-order': attributes._order,
-      'data-tooltip-id': 'adaptclose',
-      'data-event': 'closeButton'
+      ...super.attributes(),
+      'data-tooltip-id': 'adaptclose'
     };
   }
 

--- a/js/adapt-close.js
+++ b/js/adapt-close.js
@@ -11,7 +11,6 @@ class AdaptClose extends Backbone.Controller {
     this.listenToOnce(Adapt, 'adapt:start', this.onStart);
   }
 
-
   get config () {
     return Adapt.course.get('_close');
   }
@@ -50,7 +49,7 @@ class AdaptClose extends Backbone.Controller {
       _navOrder = 100,
       _showLabel = true,
       navLabel = '',
-      closeButton = ''
+      ariaLabel = ''
     } = AdaptClose.globalsConfig ?? {};
 
     const model = new NavigationButtonModel({
@@ -60,8 +59,9 @@ class AdaptClose extends Backbone.Controller {
       _classes: 'btn-icon nav__btn nav__close-btn',
       _iconClasses: '',
       _role: 'button',
-      ariaLabel: closeButton,
+      ariaLabel,
       text: navLabel,
+      _event: 'closeButton',
       config: this.config
     });
 

--- a/js/adapt-close.js
+++ b/js/adapt-close.js
@@ -49,7 +49,8 @@ class AdaptClose extends Backbone.Controller {
     const {
       _navOrder = 100,
       _showLabel = true,
-      navLabel = ''
+      navLabel = '',
+      closeButton = ''
     } = AdaptClose.globalsConfig ?? {};
 
     const model = new NavigationButtonModel({
@@ -59,6 +60,7 @@ class AdaptClose extends Backbone.Controller {
       _classes: 'btn-icon nav__btn nav__close-btn',
       _iconClasses: '',
       _role: 'button',
+      ariaLabel: closeButton,
       text: navLabel,
       config: this.config
     });

--- a/properties.schema
+++ b/properties.schema
@@ -3,9 +3,9 @@
   "$schema": "http://json-schema.org/draft-03/schema",
   "id": "http://jsonschema.net",
   "globals": {
-    "closeButton": {
+    "ariaLabel": {
       "type": "string",
-      "default": "Select here to close the window.",
+      "default": "Select here to close the course.",
       "title": "Close button ARIA label",
       "inputType": "Text",
       "translatable": true
@@ -84,14 +84,6 @@
                       "title": "Close via LMSFinish?",
                       "inputType": "Checkbox",
                       "help": "Enables closing the course via the SCORM 'finish' function rather than by closing the window - useful for LMSes that don't open the course in a new window or don't allow the course window to be closed via JavaScript."
-                    },
-                    "navigationAriaLabel": {
-                      "type": "string",
-                      "default": "Close course button",
-                      "title": "Navigation button alt text",
-                      "inputType": "Text",
-                      "required": true,
-                      "translatable": true
                     },
                     "_notifyPromptIfIncomplete": {
                       "type": "object",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -21,10 +21,10 @@
                   "title": "Close",
                   "default": {},
                   "properties": {
-                    "closeButton": {
+                    "ariaLabel": {
                       "type": "string",
                       "title": "Close button ARIA label",
-                      "default": "Select here to close the window.",
+                      "default": "Select here to close the course.",
                       "_adapt": {
                         "translatable": true
                       }
@@ -94,14 +94,6 @@
                   "title": "Close via LMSFinish?",
                   "description": "Enables closing the course via the SCORM 'finish' function rather than by closing the window - useful for LMSes that don't open the course in a new window or don't allow the course window to be closed via JavaScript.",
                   "default": false
-                },
-                "navigationAriaLabel": {
-                  "type": "string",
-                  "title": "Navigation button alt text",
-                  "default": "Close course button",
-                  "_adapt": {
-                    "translatable": true
-                  }
                 },
                 "_notifyPromptIfIncomplete": {
                   "type": "object",


### PR DESCRIPTION
Fixes #38 

Will need added to the migration scripts #37 

### Update
* Rename globals `closeButton` to `ariaLabel` and update to "Select here to close the course."
* Use `ariaLabel` for the navigation button's `aria-label` instead of `navigationAriaLabel`.
* Remove `navigationAriaLabel` that was previously used for the aria label.
* Refactor view to better align with NavigationButtonModel.